### PR TITLE
feat: implement useParams hook for interacting with query string

### DIFF
--- a/src/hooks/useQueryParams.ts
+++ b/src/hooks/useQueryParams.ts
@@ -1,0 +1,41 @@
+import { useHistory } from './useHistory'
+
+export const useQueryParams = () => {
+    const history = useHistory()
+
+    const urlParams = new URLSearchParams(window.location.search)
+
+    const get = (param: string) => {
+        for (const [key, value] of urlParams) {
+            if (param === key) {
+                return value
+            }
+        }
+    }
+
+    const getParams = () => {
+        const keys = []
+
+        for (const [key] of urlParams) {
+            keys.push(key)
+        }
+
+        return keys
+    }
+
+    const set = (name: string, value: string) => {
+        const isFound = getParams().some(key => key === name)
+
+        if (isFound) {
+            urlParams.set(name, value)
+        } else {
+            urlParams.append(name, value)
+        }
+
+        const newRelativePathQuery = window.location.pathname + '?' + urlParams.toString()
+
+        history.push(newRelativePathQuery)
+    }
+
+    return { urlParams, get, getParams, set }
+}


### PR DESCRIPTION
## Overview

### Introducing the `useParams` hook

Hi everyone,

I would introduce a new hook for accessing the URL query params.


### Example

```tsx

import './App.css'
import { useQueryParams } from './hooks/useQueryParams'
import { useEffect } from 'react'

function App() {
    const params = useQueryParams()
    const name = params.get('name')
    const param = params.getParams()

    useEffect(() => {
        console.log(name)
        console.log(param)
    }, [])

    const append = () => {
        params.set('age', '10')
    }

    return <button onClick={append}></button>
}

export default App

```