### PR TITLE
refactor: re-use deleteItem function

### DIFF
--- a/src/hooks/useLocalStorage.ts
+++ b/src/hooks/useLocalStorage.ts
@@ -63,11 +63,7 @@ export const useLocalStorage = (fn?: () => void) => {
 
     const deleteMultipleItems = (keys: string[]) => {
         keys.forEach(key => {
-            const item = checkItem(key)
-            if (item) {
-                localStorage.removeItem(key)
-                setStorage(getLocalStorageItems())
-            }
+            deleteItem(key)
         })
     }
 


### PR DESCRIPTION
## Overview

The function `deleteMultipleItems` was using the same logic as `deleteItem`.

## What's changed

- [x] Call the function `deleteItem` inside forEach.
