### PR TITLE
feat: implement useMediaQuery hook for responsive UI

### DIFF
--- a/src/hooks/use-media-query.ts
+++ b/src/hooks/use-media-query.ts
@@ -1,0 +1,74 @@
+import { useEffect, useState } from 'react'
+
+type MediaQuery = 'xs' | 'sm' | 'md' | 'lg' | 'xl'
+
+const initWidth = (type: MediaQuery): number => {
+    switch (type) {
+        case 'xs': {
+            return 320
+        }
+
+        case 'sm': {
+            return 480
+        }
+        case 'md': {
+            return 768
+        }
+
+        case 'lg': {
+            return 1024
+        }
+
+        case 'xl': {
+            return 1200
+        }
+
+        default: {
+            return 1200
+        }
+    }
+}
+
+export const useMediaQuery = (type: MediaQuery) => {
+    const initialMediaWidth = initWidth(type)
+
+    const [mediaWidth, setMediaWidth] = useState<number>(initialMediaWidth)
+
+    const resize = (type: MediaQuery) => {
+        switch (type) {
+            case 'xs': {
+                setMediaWidth(320)
+                return mediaWidth
+            }
+
+            case 'sm': {
+                setMediaWidth(480)
+                break
+            }
+            case 'md': {
+                setMediaWidth(768)
+                break
+            }
+
+            case 'lg': {
+                setMediaWidth(1024)
+                break
+            }
+
+            case 'xl': {
+                setMediaWidth(1200)
+                break
+            }
+
+            default: {
+                setMediaWidth(1200)
+            }
+        }
+    }
+
+    useEffect(() => {
+        window.addEventListener('resize', () => setMediaWidth(innerWidth))
+    }, [])
+
+    return { mediaWidth, resize }
+}


### PR DESCRIPTION
## Overview

This pull request aims to introduce a new hook for tracking the window size.#17 


## Example


```tsx

import './App.css'
import { useMediaQuery } from './hooks/use-media-query'
import { useEffect } from 'react'

function App() {
    const { mediaWidth, resize } = useMediaQuery('sm')

    useEffect(() => {
        console.log(mediaWidth)
        if (mediaWidth == 900) {
            alert('Tablet')
        }
    }, [mediaWidth])

    return <button onClick={() => resize('md')}>Resize</button>
}

export default App



```