### PR TITLE
feat: update useFetch to reject earlier calls if a later one is made

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
         "eslint-plugin-react-hooks": "^4.6.0",
         "eslint-plugin-react-refresh": "^0.4.5",
         "husky": "^8.0.3",
+        "vitest-fetch-mock": "^0.2.2",
         "jsdom": "^24.0.0",
         "lint-staged": "^15.2.0",
         "prettier": "3.0.3",

--- a/src/hooks/__tests__/use-fetch.spec.ts
+++ b/src/hooks/__tests__/use-fetch.spec.ts
@@ -1,60 +1,338 @@
 import { useFetch } from '../use-fetch'
 import { renderHook, waitFor } from '@testing-library/react'
+import { vi } from 'vitest'
+import createFetchMock from 'vitest-fetch-mock'
+
+const fetchMock = createFetchMock(vi)
 
 describe('useFetch', () => {
-    it('should fetch data immmediately', () => {
+    beforeEach(() => {
+        fetchMock.enableMocks()
+        fetchMock.mockResponse(JSON.stringify({ data: '12345' }))
+        console.log(fetch)
+    })
+    afterEach(() => {
+        fetchMock.resetMocks()
+        fetchMock.disableMocks()
+    })
+    test('should fetch data immediately', async () => {
         const url = 'https://jsonplaceholder.typicode.com/posts'
 
         const { result } = renderHook(() => useFetch(url))
 
         expect(result.current.data).toBe(undefined)
 
-        expect(result.current.error).toBe(undefined)
+        expect(result.current.loading).toBe(true)
 
-        waitFor(() => expect(result.current.data).not.toBeUndefined())
+        expect(result.current.error).toBeFalsy()
 
-        waitFor(() => expect(result.current.error).toBe(undefined))
+        await waitFor(() => expect(result.current.data).toEqual({ data: '12345' }))
 
-        waitFor(() => expect(result.current.isLoading).toBe(false))
+        await waitFor(() => expect(result.current.error).toBeFalsy())
+
+        await waitFor(() => expect(result.current.loading).toBe(false))
+
+        expect(fetchMock).toHaveBeenCalledTimes(1)
+        expect(fetchMock).toHaveBeenCalledWith(url, { signal: expect.any(AbortSignal) })
     })
 
-    it('should not fetch data immmediately trigger is false', () => {
+    test('should fetch data immediately with options when trigger is not present', async () => {
+        const url = 'https://jsonplaceholder.typicode.com/posts'
+
+        const { result } = renderHook(() => useFetch(url, { method: 'POST', body: 'hello' }))
+
+        expect(result.current.data).toBe(undefined)
+
+        expect(result.current.loading).toBe(true)
+
+        expect(result.current.error).toBeFalsy()
+
+        await waitFor(() => expect(result.current.data).toEqual({ data: '12345' }))
+
+        await waitFor(() => expect(result.current.error).toBeFalsy())
+
+        await waitFor(() => expect(result.current.loading).toBe(false))
+
+        expect(fetchMock).toHaveBeenCalledTimes(1)
+        expect(fetchMock).toHaveBeenCalledWith(url, { method: 'POST', body: 'hello', signal: expect.any(AbortSignal) })
+    })
+
+    test('should fetch data immediately when trigger is false', async () => {
         const url = 'https://jsonplaceholder.typicode.com/posts'
 
         const { result } = renderHook(() => useFetch(url, false))
 
         expect(result.current.data).toBe(undefined)
 
-        expect(result.current.error).toBe(undefined)
+        expect(result.current.error).toBeFalsy()
+
+        expect(result.current.loading).toBe(true)
+
+        await waitFor(() => {
+            expect(result.current.data).not.toBe(undefined)
+
+            expect(result.current.error).toBeFalsy()
+
+            expect(result.current.loading).toBe(false)
+        })
+
+        expect(fetchMock).toHaveBeenCalledTimes(1)
+        expect(fetchMock).toHaveBeenCalledWith(url, { signal: expect.any(AbortSignal) })
     })
 
-    it('should fetch data immediately trigger is true', () => {
+    test('should not fetch data immediately when trigger is true', async () => {
         const url = 'https://jsonplaceholder.typicode.com/posts'
 
         const { result } = renderHook(() => useFetch(url, true))
 
-        waitFor(() => expect(result.current.data).not.toBeUndefined())
+        expect(result.current.data).toBeUndefined()
+        expect(result.current.error).toBeFalsy()
+        expect(result.current.loading).toBe(false)
 
-        waitFor(() => expect(result.current.error).toBe(undefined))
+        const { data, error, aborted } = await result.current.refetch({ method: 'POST' })
 
-        waitFor(() => expect(result.current.isLoading).toBe(false))
+        expect(data).toEqual({ data: '12345' })
+        expect(error).toBeFalsy()
+        expect(aborted).toBeFalsy()
+        await waitFor(() => expect(result.current.loading).toBe(false))
+        expect(result.current.data).toEqual({ data: '12345' })
+        expect(result.current.error).toBeFalsy()
+
+        expect(fetchMock).toHaveBeenCalledTimes(1)
+        expect(fetchMock).toHaveBeenCalledWith(url, {
+            method: 'POST',
+            signal: expect.any(AbortSignal),
+        })
     })
 
-    it('should handle errors', () => {
+    test('should report error when trigger is true', async () => {
+        const url = 'https://jsonplaceholder.typicode.com/posts'
+        fetchMock.mockReject(new Error('fake error message'))
+
+        const { result } = renderHook(() => useFetch(url, true, { method: 'POST' }))
+
+        expect(result.current.data).toBeUndefined()
+        expect(result.current.error).toBeFalsy()
+        expect(result.current.loading).toBe(false)
+
+        const { data, error, aborted } = await result.current.refetch({ body: 'hello' })
+
+        expect(data).toBeFalsy()
+        expect(error?.message).toBe('fake error message')
+        expect(aborted).toBeFalsy()
+        await waitFor(() => expect(result.current.loading).toBe(false))
+        expect(result.current.data).toBeFalsy()
+        expect(result.current.error?.message).toBe('fake error message')
+
+        expect(fetchMock).toHaveBeenCalledTimes(1)
+        expect(fetchMock).toHaveBeenCalledWith(url, {
+            method: 'POST',
+            body: 'hello',
+            signal: expect.any(AbortSignal),
+        })
+    })
+
+    test('should report aborted when trigger is true', async () => {
+        const url = 'https://jsonplaceholder.typicode.com/posts'
+        fetchMock.mockResponseOnce(() => new Promise(resolve => setTimeout(() => resolve({ body: 'ok' }), 100)))
+        fetchMock.mockResponse(JSON.stringify({ data: '12345' }))
+
+        const { result } = renderHook(() => useFetch(url, true, { method: 'POST' }))
+
+        expect(result.current.data).toBeUndefined()
+        expect(result.current.error).toBeFalsy()
+        expect(result.current.loading).toBe(false)
+
+        const firstCallResponse = result.current.refetch({ body: 'hello' })
+
+        const secondCallResponse = result.current.refetch({ method: 'GET' })
+
+        await expect(firstCallResponse).resolves.toEqual({
+            data: undefined,
+            error: undefined,
+            aborted: true,
+        })
+
+        await expect(secondCallResponse).resolves.toEqual({
+            data: { data: '12345' },
+            error: undefined,
+            aborted: undefined,
+        })
+
+        await waitFor(() => expect(result.current.loading).toBe(false))
+        expect(result.current.data).toEqual({ data: '12345' })
+        expect(result.current.error).toBeFalsy()
+
+        expect(fetchMock).toHaveBeenCalledTimes(2)
+        expect(fetchMock).toHaveBeenCalledWith(url, {
+            method: 'POST',
+            body: 'hello',
+            signal: expect.any(AbortSignal),
+        })
+        expect(fetchMock).toHaveBeenCalledWith(url, {
+            method: 'GET',
+            signal: expect.any(AbortSignal),
+        })
+    })
+
+    test('should handle errors', async () => {
         const url = 'https://jsonplaceholder.typicode.com/wrong'
+        fetchMock.mockReject(new Error('fake error message'))
+
+        const { result } = renderHook(() =>
+            useFetch(url, {
+                method: 'POST',
+                body: 'hello',
+                signal: expect.any(AbortSignal),
+            }),
+        )
+
+        expect(result.current.data).toBe(undefined)
+
+        expect(result.current.error).toBeFalsy()
+
+        await waitFor(() => {
+            expect(result.current.data).toBeUndefined()
+
+            expect(result.current.error?.message).toEqual('fake error message')
+
+            expect(result.current.loading).toBe(false)
+        })
+
+        expect(fetchMock).toHaveBeenCalledTimes(1)
+        expect(fetchMock).toHaveBeenCalledWith(url, {
+            method: 'POST',
+            body: 'hello',
+            signal: expect.any(AbortSignal),
+        })
+    })
+
+    test('should handle http error responses', async () => {
+        const url = 'https://jsonplaceholder.typicode.com/postie'
+        fetchMock.mockResponse('Not found', {
+            status: 404,
+        })
 
         const { result } = renderHook(() => useFetch(url))
 
         expect(result.current.data).toBe(undefined)
 
-        expect(result.current.error).toBe(undefined)
+        expect(result.current.error).toBeFalsy()
 
-        waitFor(() => {
+        await waitFor(() => {
             expect(result.current.data).toBeUndefined()
 
-            expect(result.current.error?.message.length).toBeGreaterThan(0)
+            expect(result.current.error?.message).toEqual('HTTP error! Status: 404')
 
-            expect(result.current.isLoading).toBe(false)
+            expect(result.current.loading).toBe(false)
         })
+
+        expect(fetchMock).toHaveBeenCalledTimes(1)
+        expect(fetchMock).toHaveBeenCalledWith(url, { signal: expect.any(AbortSignal) })
+    })
+
+    test('should not use previous data returned after subsequent calls', async () => {
+        const url = 'https://jsonplaceholder.typicode.com/'
+        let firstCallResolved = false
+        let firstCallResolve
+        let secondCallResolve
+        fetchMock.mockResponse(request => {
+            if (request.url.endsWith('1')) {
+                return new Promise(resolve => {
+                    firstCallResolve = () => resolve(JSON.stringify({ data: '12345' }))
+                    firstCallResolved = true
+                })
+            } else {
+                return new Promise(resolve => {
+                    secondCallResolve = () => resolve(JSON.stringify({ data: '67890' }))
+                })
+            }
+        })
+
+        const initialProps = `${url}1`
+        const { result, rerender } = renderHook((hookUrl: string) => useFetch(hookUrl), {
+            initialProps,
+        })
+
+        expect(result.current.data).toBeUndefined()
+
+        expect(result.current.error).toBeFalsy()
+
+        expect(result.current.loading).toBe(true)
+
+        rerender(`${url}2`)
+        firstCallResolve!()
+
+        await waitFor(() => {
+            expect(firstCallResolved).toBeTruthy()
+        })
+
+        expect(result.current.data).toBeUndefined()
+        expect(result.current.error).toBeFalsy()
+        expect(result.current.loading).toBe(true)
+
+        secondCallResolve!()
+
+        await waitFor(() => {
+            expect(result.current.loading).toBe(false)
+        })
+        expect(result.current.data).toEqual({ data: '67890' })
+        expect(result.current.error).toBeFalsy()
+
+        expect(fetchMock).toHaveBeenCalledTimes(2)
+        expect(fetchMock).toHaveBeenCalledWith(url + 1, { signal: expect.any(AbortSignal) })
+        expect(fetchMock).toHaveBeenCalledWith(url + 2, { signal: expect.any(AbortSignal) })
+    })
+
+    test('should rerender when url changes', async () => {
+        const url1 = 'https://jsonplaceholder.typicode.com/posts/1'
+        const url2 = 'https://jsonplaceholder.typicode.com/posts/2'
+
+        const { rerender } = renderHook(hookUrl => useFetch(hookUrl), {
+            initialProps: url1,
+        })
+
+        rerender(url2)
+
+        expect(fetchMock).toHaveBeenCalledTimes(2)
+        expect(fetchMock).toHaveBeenCalledWith(url1, { signal: expect.any(AbortSignal) })
+        expect(fetchMock).toHaveBeenCalledWith(url2, { signal: expect.any(AbortSignal) })
+    })
+
+    test('should rerender when options change', async () => {
+        const url = 'https://jsonplaceholder.typicode.com/'
+
+        const initialProps = {
+            method: 'POST',
+        }
+        const { rerender } = renderHook((options: RequestInit) => useFetch(url, options), {
+            initialProps,
+        })
+
+        rerender({
+            method: 'POST',
+            body: 'hello',
+        })
+
+        expect(fetchMock).toHaveBeenCalledTimes(2)
+        expect(fetchMock).toHaveBeenCalledWith(url, { signal: expect.any(AbortSignal), method: 'POST' })
+        expect(fetchMock).toHaveBeenCalledWith(url, { signal: expect.any(AbortSignal), method: 'POST', body: 'hello' })
+    })
+
+    test('should not rerender when options do not change', async () => {
+        const url = 'https://jsonplaceholder.typicode.com/'
+
+        const { rerender } = renderHook((options: RequestInit) => useFetch(url, options), {
+            initialProps: {
+                method: 'POST',
+            },
+        })
+
+        rerender({
+            method: 'POST',
+        })
+
+        expect(fetchMock).toHaveBeenCalledTimes(1)
+        expect(fetchMock).toHaveBeenCalledWith(url, { signal: expect.any(AbortSignal), method: 'POST' })
     })
 })

--- a/src/hooks/use-fetch.ts
+++ b/src/hooks/use-fetch.ts
@@ -1,49 +1,113 @@
-import { useEffect, useState } from 'react'
+// This hook does not deal with caching, de-bouncing or de-duping
+// I would seriously consider using TanStack Query instead of this hook
+import { useCallback, useEffect, useRef, useState } from 'react'
 
-export const useFetch = <DataType>(url: string, trigger = true, requestOptions?: RequestInit) => {
-    const [error, setError] = useState<Error | undefined>(undefined)
+type UseFetchResponse<T> = {
+    data?: T
+    loading?: boolean
+    error?: Error
+    refetch: (options?: RequestInit) => Promise<{ data?: T; error?: Error; aborted?: boolean }>
+}
+type UseFetch = {
+    <T>(url: string): UseFetchResponse<T>
+    <T>(url: string, trigger: boolean): UseFetchResponse<T>
+    <T>(url: string, requestOptions: RequestInit): UseFetchResponse<T>
+    <T>(url: string, trigger: boolean, requestOptions: RequestInit): UseFetchResponse<T>
+}
 
-    const [data, setData] = useState<DataType | undefined>(undefined)
+const deepEqual = (a: unknown, b: unknown): boolean => {
+    if (a === b) {
+        return true
+    }
+    if (!(a instanceof Object) || !(b instanceof Object)) {
+        return false
+    }
+    if (a.constructor !== b.constructor) {
+        return false
+    }
+    const aKeys = Object.keys(a)
+    const bKeys = Object.keys(b)
 
-    const [isLoading, setIsLoading] = useState(!trigger || false)
-
-    const [isTriggered, setIsTriggered] = useState(trigger)
-
-    const startTrigger = () => setIsTriggered(true)
-
-    const fetchData = async () => {
-        try {
-            setIsLoading(true)
-
-            const response = await fetch(url, requestOptions)
-
-            if (!response.ok) {
-                throw new Error(`HTTP error! Status: ${response.status}`)
-            }
-
-            const result = await response.json()
-
-            setData(result)
-
-            setError(undefined)
-        } catch (error) {
-            if (error instanceof Error) {
-                setError(error)
-            }
-        } finally {
-            setIsLoading(false)
-        }
+    if (aKeys.length !== bKeys.length || aKeys.some(key => !bKeys.includes(key))) {
+        return false
     }
 
-    useEffect(() => {
-        setIsTriggered(trigger)
-    }, [trigger])
+    return aKeys.every(key => deepEqual(a[key as keyof typeof a], b[key as keyof typeof b]))
+}
+
+export const useFetch: UseFetch = <T = unknown>(
+    url: string,
+    trigger?: boolean | RequestInit,
+    options?: RequestInit,
+): UseFetchResponse<T> => {
+    const requestOptions = typeof trigger === 'boolean' ? options : trigger || {}
+    const hasTrigger = typeof trigger === 'boolean' ? trigger : false
+
+    const abortControllerRef = useRef<AbortController>()
+    const requestOptionsRef = useRef<unknown>(requestOptions)
+    const requestOptionsChanged = useRef(Symbol())
+    if (!deepEqual(requestOptions, requestOptionsRef.current)) {
+        requestOptionsRef.current = requestOptions
+        requestOptionsChanged.current = Symbol()
+    }
+
+    const [error, setError] = useState<Error>()
+    const [data, setData] = useState<T>()
+    const [loading, setLoading] = useState(false)
+
+    const fetchData = useCallback(
+        async (options: RequestInit = {}) => {
+            setLoading(true)
+            if (abortControllerRef.current) {
+                abortControllerRef.current.abort()
+            }
+            const abortController = new AbortController()
+            abortControllerRef.current = abortController
+            try {
+                const response = await fetch(url, { signal: abortController.signal, ...requestOptions, ...options })
+
+                if (abortControllerRef.current !== abortController) {
+                    // this should never happen because the call should have been aborted and fallen into the error handler
+                    return { aborted: true }
+                }
+                if (!response.ok) {
+                    throw new Error(`HTTP error! Status: ${response.status}`)
+                }
+
+                const result: T = await response.json()
+
+                setData(result)
+                return { data: result }
+            } catch (error) {
+                if (abortControllerRef.current !== abortController) {
+                    return { aborted: true }
+                }
+                setData(undefined)
+                let normalisedError = new Error('Unknown Error')
+                if (error instanceof Error) {
+                    normalisedError = error
+                }
+                if (typeof error === 'string') {
+                    normalisedError = new Error(error)
+                }
+                setError(normalisedError)
+                return { error: normalisedError }
+            } finally {
+                if (abortControllerRef.current === abortController) {
+                    setLoading(false)
+                    abortControllerRef.current = undefined
+                }
+            }
+        },
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+        [url, requestOptionsChanged.current],
+    )
 
     useEffect(() => {
-        if (isTriggered) {
+        if (!hasTrigger) {
             fetchData()
         }
-    }, [isTriggered])
+    }, [hasTrigger, fetchData])
 
-    return { data, isLoading, error, refetch: fetchData, trigger: startTrigger }
+    return { data, loading, error, refetch: fetchData }
 }


### PR DESCRIPTION
As requested on https://blog.stackademic.com/5-custom-react-hooks-every-developer-should-know-4183af96cecc, I've updated useFetch hook to resolve some of the issues.